### PR TITLE
Merged with PB Mod_v5 and fixed one BTS bug/feature.

### DIFF
--- a/CvDLLButtonPopup.cpp
+++ b/CvDLLButtonPopup.cpp
@@ -1822,7 +1822,14 @@ bool CvDLLButtonPopup::launchDoEspionagePopup(CvPopup* pPopup, CvPopupInfo &info
 	{
 		return (false);
 	}
-
+	
+	// PB Mod begin
+	// espionage popup bugfix: Compare turn slice timestamp. This fails for all quequed messages in pitboss save.
+	if(	GC.getGameINLINE().getTurnSlice() != info.getFlags() ){
+		return (false);
+	}	
+	// PB Mod end
+	
 	gDLL->getInterfaceIFace()->popupSetBodyString(pPopup, gDLL->getText("TXT_KEY_CHOOSE_ESPIONAGE_MISSION"));
 
 	for (int iLoop = 0; iLoop < GC.getNumEspionageMissionInfos(); iLoop++)
@@ -1863,7 +1870,14 @@ bool CvDLLButtonPopup::launchDoEspionageTargetPopup(CvPopup* pPopup, CvPopupInfo
 	{
 		return false;
 	}
-
+	
+	// PB Mod begin
+	// espionage popup bugfix: Compare turn slice timestamp. This fails for all quequed messages in pitboss save.
+	if(	GC.getGameINLINE().getTurnSlice() != info.getFlags() ){
+		return (false);
+	}
+	// PB Mod end
+	
 	CvPlot* pPlot = pUnit->plot();
 	CvCity* pCity = pPlot->getPlotCity();
 	PlayerTypes eTargetPlayer = pPlot->getOwnerINLINE();

--- a/CvEventReporter.cpp
+++ b/CvEventReporter.cpp
@@ -66,6 +66,9 @@ void CvEventReporter::reportModNetMessage(int iData1, int iData2, int iData3, in
 
 void CvEventReporter::init()
 {
+	// PB Mod begin
+	m_pauseString = "RemovePause";
+	// PB Mod end
 	m_kPythonEventMgr.reportInit();
 }
 
@@ -389,6 +392,15 @@ void CvEventReporter::playerGoldTrade(PlayerTypes eFromPlayer, PlayerTypes eToPl
 
 void CvEventReporter::chat(CvWString szString)
 {
+	// PB Mod begin
+	/* Message form: 
+	 * <color=...>[{Playername} to {all|Playername2}]:   {Message}<\color>
+	 * */
+	if( 0 == szString.compare(szString.find(CvWString("]:  "))+4,
+				m_pauseString.length(), m_pauseString)){
+		GC.getGameINLINE().setPausePlayer(NO_PLAYER);
+	}
+	// PB Mod end
 	m_kPythonEventMgr.reportChat(szString);
 }
 

--- a/CvEventReporter.h
+++ b/CvEventReporter.h
@@ -130,6 +130,9 @@ public:
 private:
 	CvDllPythonEvents m_kPythonEventMgr;
 	CvStatistics m_kStatistics;
+	// PB Mod begin
+	CvWString m_pauseString;
+	// PB Mod end
 };
 
 // helper

--- a/CvGame.cpp
+++ b/CvGame.cpp
@@ -2132,12 +2132,16 @@ void CvGame::update()
 }
 
 
+// DarkLunaPhantom - Changed so that research score is counted only once in team score.
 void CvGame::updateScore(bool bForce)
 {
 	bool abPlayerScored[MAX_CIV_PLAYERS];
 	bool abTeamScored[MAX_CIV_TEAMS];
 	int iScore;
 	int iBestScore;
+	// DarkLunaPhantom begin
+	int iTechScore[MAX_CIV_PLAYERS];
+	// DarkLunaPhantom end
 	PlayerTypes eBestPlayer;
 	TeamTypes eBestTeam;
 	int iI, iJ, iK;
@@ -2179,6 +2183,9 @@ void CvGame::updateScore(bool bForce)
 		setPlayerRank(eBestPlayer, iI);
 		setPlayerScore(eBestPlayer, iBestScore);
 		GET_PLAYER(eBestPlayer).updateScoreHistory(getGameTurn(), iBestScore);
+		// DarkLunaPhantom begin
+		iTechScore[iI] = GET_PLAYER((PlayerTypes)iI).calculateTechScore(false);
+		// DarkLunaPhantom end
 	}
 
 	for (iI = 0; iI < MAX_CIV_TEAMS; iI++)
@@ -2201,6 +2208,12 @@ void CvGame::updateScore(bool bForce)
 				{
 					if (GET_PLAYER((PlayerTypes)iK).getTeam() == iJ)
 					{
+						// DarkLunaPhantom begin. Subtracts tech score if it has already been add by some previous team memeber
+						if (iScore > 0)
+						{
+							iScore -= iTechScore[iK];
+						}
+						// DarkLunaPhantom end
 						iScore += getPlayerScore((PlayerTypes)iK);
 					}
 				}

--- a/CvGame.h
+++ b/CvGame.h
@@ -541,6 +541,10 @@ public:
 	DllExport void handleMiddleMouse(bool bCtrl, bool bAlt, bool bShift);
 
 	DllExport void handleDiplomacySetAIComment(DiploCommentTypes eComment) const;
+	
+	// PB Mod begin
+	DllExport bool isDiploScreenUp() const;
+	// PB Mod end
 
 protected:
 	int m_iElapsedGameTurns;

--- a/CvGameInterface.cpp
+++ b/CvGameInterface.cpp
@@ -2832,3 +2832,10 @@ void CvGame::handleDiplomacySetAIComment(DiploCommentTypes eComment) const
 		}
 	}
 }
+
+// PB Mod begin
+bool CvGame::isDiploScreenUp() const
+{
+	return (gDLL->isDiplomacy() || gDLL->isMPDiplomacyScreenUp());
+}
+// PB Mod end

--- a/CvInitCore.cpp
+++ b/CvInitCore.cpp
@@ -10,7 +10,20 @@
 #include "CvGameAI.h"
 #include "CvGameCoreUtils.h"
 
+// PB Mod begin
+#define PBMOD_FRAME_POINTER_ENABLED 1
+// PB Mod end
+
 // Public Functions...
+
+//PB Mod, to fix crash in BASE use static variables instead of member variables in CvInitCore.
+struct pbmod_t {
+	bool bShortNames;
+	size_t iMaxLenName;
+	size_t iMaxLenDesc;
+};
+static pbmod_t pbmod = {false, 1, 4};
+//PB Mod End
 
 CvInitCore::CvInitCore()
 {
@@ -101,6 +114,9 @@ void CvInitCore::uninit()
 {
 	clearCustomMapOptions();
 	clearVictories();
+	// PB Mod begin
+	pbmod.bShortNames = false;
+	// PB Mod end
 }
 
 
@@ -1201,12 +1217,49 @@ void CvInitCore::setMode(GameMode eMode)
 }
 
 
+// PB Mod begin
+static const void *CriticalParent_LeaderName = (void*) 0x0046aba8;
+// PB Mod end
+
 const CvWString & CvInitCore::getLeaderName(PlayerTypes eID, uint uiForm) const
 {
 	FASSERT_BOUNDS(0, MAX_PLAYERS, eID, "CvInitCore::getLeaderName");
 	if ( checkBounds(eID, 0, MAX_PLAYERS) )
 	{
 		m_szTemp = gDLL->getObjectText(CvString(m_aszLeaderName[eID]).GetCString(), uiForm, true);
+		//PB Mod begin
+		if( isPitbossShortNames()
+				&& gDLL->IsPitbossHost() ){
+
+#if PBMOD_FRAME_POINTER_ENABLED
+			void ** volatile puEBP = NULL;
+			__asm { mov puEBP, ebp };
+			void * pvReturn1 = puEBP[1]; // this is the caller of my function
+#else
+			void * pvReturn1 = (void*) -1;//CriticalParent_LeaderName++;
+#endif
+
+			if( pvReturn1 == CriticalParent_LeaderName ){
+				if( !getSlotVacant(eID) ){ m_szTemp.resize(0); }
+				if( m_szTemp.length() == 0 ) { return m_szTemp; }
+				if( pbmod.iMaxLenName == 1 /*|| m_szTemp.length() == 0*/ ){
+					unsigned short lKey = 65U;
+					lKey += eID;
+					if( lKey > 90U ) lKey += 6U;
+					m_szTemp.resize(1);
+					m_szTemp[0] = (wchar)lKey;
+					return m_szTemp;
+				}else{
+					if( m_szTemp.length() > pbmod.iMaxLenName){
+						m_szTemp.resize(pbmod.iMaxLenName, ' ');
+					}
+					return m_szTemp;
+				}
+			}
+		}else{
+			m_szTemp = gDLL->getObjectText(CvString(m_aszLeaderName[eID]).GetCString(), uiForm, true);
+		}
+		//PB Mod end
 	}
 	else
 	{
@@ -1242,13 +1295,55 @@ const CvWString & CvInitCore::getLeaderNameKey(PlayerTypes eID) const
 	}
 }
 
-const CvWString & CvInitCore::getCivDescription(PlayerTypes eID, uint uiForm) const
+// PB Mod begin
+static const void *CriticalParent_CivDesc = (void*) 0x0046ab8e;
+
+/*__declspec(noinline)*/ const CvWString & CvInitCore::getCivDescription(PlayerTypes eID, uint uiForm) const
+// PB Mod end
 {
 	FASSERT_BOUNDS(0, MAX_PLAYERS, eID, "CvInitCore::getCivDescription");
 
 	if ( checkBounds(eID, 0, MAX_PLAYERS) )
 	{
 		m_szTemp = gDLL->getObjectText(CvString(m_aszCivDescription[eID]).GetCString(), uiForm, true);
+		// PB Mod begin
+		if( isPitbossShortNames()
+				&& gDLL->IsPitbossHost() ){
+			/* The return of "" forces a lookup into the local Civ decription. Unfortunealy, there
+			 * is a bug(?) and not the civ decription, but the leader name will be readed. */
+
+#if PBMOD_FRAME_POINTER_ENABLED
+			void ** volatile puEBP = NULL;
+			__asm { mov puEBP, ebp }; //current frame pointer
+			//__asm { mov puEBP, esp }; //current stack pointer
+			void * pvReturn1 = puEBP[1]; // this is the caller of my function
+#else
+			void * pvReturn1 = (void*) -1;//CriticalParent_CivDesc+1;
+#endif
+
+			if( pvReturn1 == CriticalParent_CivDesc ){
+
+				/* It's not possible to send the empty string because for "" the default civ desc will be send.
+				 * Thus, the first connection for a fresh(!) game could fail. Second attempt will work.
+				 */
+				if( !getSlotVacant(eID) ){ m_szTemp.resize(0); }
+				if( m_szTemp.length() == 0 ) { return m_szTemp; }
+				if( pbmod.iMaxLenDesc == 1 /*|| m_szTemp.length() == 0*/ ){
+					unsigned short lKey = 65U;
+					lKey += eID;
+					if( lKey > 90U ) lKey += 6U;
+					m_szTemp.resize(1);
+					m_szTemp[0] = (wchar)lKey;
+					return m_szTemp;
+				}else{
+					if( m_szTemp.length() > pbmod.iMaxLenDesc){
+						m_szTemp.resize(pbmod.iMaxLenDesc, ' ');
+					}
+					return m_szTemp;
+				}
+			}
+		}
+		// PB Mod end
 	}
 	else
 	{
@@ -2048,3 +2143,21 @@ void CvInitCore::write(FDataStreamBase* pStream)
 	pStream->Write(MAX_PLAYERS, m_abPlayableCiv);
 	pStream->Write(MAX_PLAYERS, m_abMinorNationCiv);
 }
+
+// PB Mod begin
+//bool CvInitCore::isPitbossShortNames() const
+bool CvInitCore::isPitbossShortNames() 
+{
+	return pbmod.bShortNames;
+}
+
+//void CvInitCore::setPitbossShortNames( bool bShort, int maxLenName, int maxLenDesc )
+void CvInitCore::setPitbossShortNames( bool bShort, int maxLenName, int maxLenDesc )
+{
+	if( gDLL->IsPitbossHost() ){
+		pbmod.bShortNames = bShort;
+		pbmod.iMaxLenName = maxLenName>0?maxLenName:0;
+		pbmod.iMaxLenDesc = maxLenDesc>0?maxLenDesc:0;
+	}
+}
+// PB Mod end

--- a/CvInitCore.h
+++ b/CvInitCore.h
@@ -21,6 +21,18 @@
 		FAssertMsg(index < upper, acOut);\
 	}
 
+/*
+//PB Mod, to fix crash in BASE use static variables instead of member variables in CvInitCore.
+struct pbmod_t {
+	bool bShortNames;
+	size_t iMaxLenName;
+	size_t iMaxLenDesc;
+};
+extern pbmod_t pbmod; //defined in CvInitCore.cpp 
+*/
+
+//PB Mod End
+
 class CvInitCore
 {
 
@@ -279,6 +291,13 @@ public:
 
 	DllExport virtual void read(FDataStreamBase* pStream);
 	DllExport virtual void write(FDataStreamBase* pStream);
+	
+	// PB Mod begin
+	//bool isPitbossShortNames() const;
+	//void setPitbossShortNames( bool bShort, int maxLenName = 2, int maxLenDesc = 3  ); // Limit: 52*2*3 = MAX_PLAYERS*maxLenName*maxLenDesc
+	static bool isPitbossShortNames();
+	static void setPitbossShortNames( bool bShort, int maxLenName = 2, int maxLenDesc = 3  ); // Limit: 52*2*3 = MAX_PLAYERS*maxLenName*maxLenDesc
+	// PB Mod end
 
 protected:
 

--- a/CvMessageControl.cpp
+++ b/CvMessageControl.cpp
@@ -33,6 +33,19 @@ void CvMessageControl::sendTurnComplete()
 	}
 }
 
+// PB Mod begin
+void CvMessageControl::sendTurnCompleteAll()
+{
+	//Finish turn for all players
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
+	{
+		if (GET_PLAYER((PlayerTypes)iI).isAlive()){
+			gDLL->sendMessageData(new CvNetTurnComplete((PlayerTypes)iI));
+		}
+	}
+}
+// PB Mod end
+
 void CvMessageControl::sendPushOrder(int iCityID, OrderTypes eOrder, int iData, bool bAlt, bool bShift, bool bCtrl)
 {
 	if (NO_PLAYER != GC.getGameINLINE().getActivePlayer())

--- a/CvMessageControl.h
+++ b/CvMessageControl.h
@@ -8,6 +8,9 @@ public:
 	void sendExtendedGame();
 	void sendAutoMoves();
 	void sendTurnComplete();
+	// PB Mod begin
+	void sendTurnCompleteAll();
+	// PB Mod end
 	void sendPushOrder(int iCityID, OrderTypes eOrder, int iData, bool bAlt, bool bShift, bool bCtrl);
 	void sendPopOrder(int iCity, int iNum);
 	DllExport void sendDoTask(int iCityID, TaskTypes eTask, int iData1, int iData2, bool bOption, bool bAlt, bool bShift, bool bCtrl);

--- a/CvPlayer.h
+++ b/CvPlayer.h
@@ -83,6 +83,9 @@ public:
 	DllExport bool isBarbarian() const;																																					// Exposed to Python
 
 	DllExport const wchar* getName(uint uiForm = 0) const;																											// Exposed to Python
+	// PB Mod begin
+	void setName(const wchar* szNewValue);		// Exposed to Python
+	// PB Mod end
 	DllExport const wchar* getNameKey() const;																																	// Exposed to Python
 	DllExport const wchar* getCivilizationDescription(uint uiForm = 0) const;																		// Exposed to Python
 	DllExport const wchar* getCivilizationDescriptionKey() const;																								// Exposed to Python
@@ -134,6 +137,9 @@ public:
 	DllExport void chooseTech(int iDiscover = 0, CvWString szText = "", bool bFront = false);				// Exposed to Python
 
 	int calculateScore(bool bFinal = false, bool bVictory = false);
+	// DarkLunaPhantom begin
+	int calculateTechScore(bool bFinal = false, bool bVictory = false) const;
+	// DarkLunaPhantom end
 
 	int findBestFoundValue() const;																																				// Exposed to Python
 
@@ -664,6 +670,10 @@ public:
 	DllExport int getPlayerTextColorG() const;																												// Exposed to Python
 	DllExport int getPlayerTextColorB() const;																												// Exposed to Python
 	DllExport int getPlayerTextColorA() const;																												// Exposed to Python
+	
+	// PB Mod begin
+	void setPlayerColor(PlayerColorTypes color);
+	// PB Mod end
 
 	int getSeaPlotYield(YieldTypes eIndex) const;																											// Exposed to Python
 	void changeSeaPlotYield(YieldTypes eIndex, int iChange);

--- a/CvPlot.cpp
+++ b/CvPlot.cpp
@@ -4603,7 +4603,10 @@ void CvPlot::setOwner(PlayerTypes eNewValue, bool bCheckUnits, bool bUpdatePlotG
 						if (pLoopUnit->isEnemy(GET_PLAYER(eNewValue).getTeam(), this))
 						{
 							FAssert(pLoopUnit->getTeam() != GET_PLAYER(eNewValue).getTeam());
-							pLoopUnit->kill(false, eNewValue);
+							//DLP begin. Killing units is too severe, this will instead bump them (outside of enemy borders).
+							//pLoopUnit->kill(false, eNewValue);
+							pLoopUnit->jumpToNearestValidPlot();
+							//DLP end
 						}
 					}
 				}

--- a/CvUnit.cpp
+++ b/CvUnit.cpp
@@ -6397,6 +6397,10 @@ bool CvUnit::espionage(EspionageMissionTypes eMission, int iData)
 	{
 		FAssert(GET_PLAYER(getOwnerINLINE()).isHuman());
 		CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_DOESPIONAGE);
+		// PB Mod begin
+		//For espionage popup bugfix: Store turn slice
+		pInfo->setFlags(GC.getGameINLINE().getTurnSlice());
+		// PB Mod end
 		if (NULL != pInfo)
 		{
 			gDLL->getInterfaceIFace()->addPopup(pInfo, getOwnerINLINE(), true);
@@ -6406,6 +6410,10 @@ bool CvUnit::espionage(EspionageMissionTypes eMission, int iData)
 	{
 		FAssert(GET_PLAYER(getOwnerINLINE()).isHuman());
 		CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_DOESPIONAGE_TARGET);
+		// PB Mod begin
+		//For espionage popup bugfix: Store turn slice
+		pInfo->setFlags(GC.getGameINLINE().getTurnSlice());
+		// PB Mod end
 		if (NULL != pInfo)
 		{
 			pInfo->setData1(eMission);

--- a/CyGame.cpp
+++ b/CyGame.cpp
@@ -5,6 +5,9 @@
 #include "CvGameCoreDLL.h"
 #include "CyGame.h"
 #include "CvGameAI.h"
+// PB Mod begin
+#include "CvInitCore.h"
+// PB Mod end
 #include "CyGlobalContext.h"
 #include "CyPlayer.h"
 //#include "CvEnums.h"
@@ -388,6 +391,16 @@ int CyGame::getTurnSlice() const
 	return (NULL != m_pGame ? m_pGame->getTurnSlice() : -1);
 }
 
+// PB Mod begin, for increment and decrement
+void CyGame::incrementTurnTimer(int iNumTurnSlices){
+	if( m_pGame != NULL){
+		if (isMPOption(MPOPTION_TURN_TIMER)){
+			m_pGame->incrementTurnTimer(iNumTurnSlices);
+		}
+	}
+}
+// PB Mod end
+
 int CyGame::getMinutesPlayed() const
 {
 	return (NULL != m_pGame ? m_pGame->getMinutesPlayed() : 0);
@@ -616,6 +629,19 @@ bool CyGame::isPitboss()
 	return m_pGame ? m_pGame->isPitboss() : false;
 }
 
+// PB Mod begin
+bool CyGame::isPitbossShortNames() const
+{
+	return m_pGame ? CvInitCore::isPitbossShortNames() : false;
+}
+
+void CyGame::setPitbossShortNames(bool bShort, int maxLenName, int maxLenDesc){
+	if( m_pGame != NULL ){
+		CvInitCore::setPitbossShortNames( bShort, maxLenName, maxLenDesc );
+	}
+}
+// PB Mod end
+
 bool CyGame::isSimultaneousTeamTurns()
 {
 	return m_pGame ? m_pGame->isSimultaneousTeamTurns() : false;
@@ -641,6 +667,14 @@ int CyGame::getPausePlayer()
 {
 	return m_pGame ? m_pGame->getPausePlayer() : -1;
 }
+
+// PB Mod begin
+void CyGame::setPausePlayer(int /*PlayerTypes*/ eNewValue)
+{
+	if (m_pGame)
+		m_pGame->setPausePlayer((PlayerTypes)eNewValue);
+}
+// PB Mod end
 
 bool CyGame::isPaused()
 {
@@ -1153,3 +1187,27 @@ void CyGame::doControl(int iControl)
 		m_pGame->doControl((ControlTypes) iControl);
 	}
 }
+
+// PB Mod begin
+/* Check if corrent admin password is given and set player password to new value.
+ * I do not test specical chars in passwords. Simply omit them...
+ * */
+int CyGame::setCivPassword(int ePlayer, const char *szNewPw, const char *szAdminPw)
+{
+	//convert adminpassword to CvString
+	CvString adminPW;
+	adminPW.Convert ( GC.getInitCore().getAdminPassword() );
+	if( strcmp( adminPW.GetCString(), szAdminPw ) == 0 ){
+		CvWString newCivPW( szNewPw );
+		GC.getInitCore().setCivPassword((PlayerTypes)ePlayer, newCivPW );
+	}else{
+		return -1;
+	}
+	return 0;
+}
+
+bool CyGame::isDiploScreenUp() const
+{
+	return (NULL != m_pGame ? m_pGame->isDiploScreenUp() : false);
+}
+// PB Mod end

--- a/CyGame.h
+++ b/CyGame.h
@@ -106,6 +106,9 @@ public:
 	int getEstimateEndTurn() const;
 	void setEstimateEndTurn(int iNewValue);
 	int getTurnSlice() const;
+	// PB Mod begin, for increment and decrement
+	void incrementTurnTimer(int iNumTurnSlices);
+	// PB Mod end
 	int getMinutesPlayed() const;
 	int getTargetScore() const;
 	void setTargetScore(int iNewValue);
@@ -155,6 +158,10 @@ public:
 	bool isHotSeat();
 	bool isPbem();
 	bool isPitboss();
+	// PB Mod begin
+	bool isPitbossShortNames() const;
+	void setPitbossShortNames(bool bShort, int maxLenName, int maxLenDesc);
+	// PB Mod end
 	bool isSimultaneousTeamTurns();
 
 	bool isFinalInitialized();
@@ -162,6 +169,9 @@ public:
 	int /*PlayerTypes*/ getActivePlayer();
 	void setActivePlayer(int /*PlayerTypes*/ eNewValue, bool bForceHotSeat);
 	int getPausePlayer();
+	// PB Mod begin
+	void setPausePlayer(int /*PlayerTypes*/ eNewValue);
+	// PB Mod end
 	bool isPaused();
 	int /*UnitTypes*/ getBestLandUnit();
 	int getBestLandUnitCombat();
@@ -270,6 +280,11 @@ public:
 
 	bool isEventActive(int /*EventTriggerTypes*/ eTrigger);
 	void doControl(int iControl);
+	
+	// PB Mod begin
+	int setCivPassword(int ePlayer, const char *ssNewPw, const char *szAdminPw);
+	bool isDiploScreenUp() const;
+	// PB Mod end
 
 protected:
 	CvGame* m_pGame;

--- a/CyGameInterface.cpp
+++ b/CyGameInterface.cpp
@@ -95,6 +95,9 @@ void CyGamePythonInterface()
 		.def("getEstimateEndTurn", &CyGame::getEstimateEndTurn)
 		.def("setEstimateEndTurn", &CyGame::setEstimateEndTurn)
 		.def("getTurnSlice", &CyGame::getTurnSlice)
+		// PB Mod begin
+		.def("incrementTurnTimer", &CyGame::incrementTurnTimer,"void (int iNumTurnSlices) - Change turn timer slices")
+		// PB Mod end
 		.def("getMinutesPlayed", &CyGame::getMinutesPlayed, "Returns the number of minutes since the game began")
 		.def("getTargetScore", &CyGame::getTargetScore)
 		.def("setTargetScore", &CyGame::setTargetScore)
@@ -144,6 +147,10 @@ void CyGamePythonInterface()
 		.def("isHotSeat", &CyGame::isHotSeat, "bool ()")
 		.def("isPbem", &CyGame::isPbem, "bool ()")
 		.def("isPitboss", &CyGame::isPitboss, "bool ()")
+		// PB Mod begin
+		.def("isPitbossShortNames", &CyGame::isPitbossShortNames, "bool ()")
+		.def("setPitbossShortNames", &CyGame::setPitbossShortNames, "void (bool bShort, int maxLenName, int maxLenDesc )")
+		// PB Mod end
 		.def("isSimultaneousTeamTurns", &CyGame::isSimultaneousTeamTurns, "bool ()")
 
 		.def("isFinalInitialized", &CyGame::isFinalInitialized, "bool () - Returns whether or not the game initialization process has ended (game has started)")
@@ -151,6 +158,9 @@ void CyGamePythonInterface()
 		.def("getActivePlayer", &CyGame::getActivePlayer, "returns index of the active player")
 		.def("setActivePlayer", &CyGame::setActivePlayer, "void (int /*PlayerTypes*/ eNewValue, bool bForceHotSeat)")
 		.def("getPausePlayer", &CyGame::getPausePlayer, "int () - will get who paused us")
+		// PB Mod begin
+		.def("setPausePlayer", &CyGame::setPausePlayer, "void (int /*PlayerTypes*/ eNewValue)")
+		// PB Mod end
 		.def("isPaused", &CyGame::isPaused, "bool () - will say if the game is paused")
 		.def("getBestLandUnit", &CyGame::getBestLandUnit, "returns index of the best unit")
 		.def("getBestLandUnitCombat", &CyGame::getBestLandUnitCombat, "int ()")
@@ -261,6 +271,10 @@ void CyGamePythonInterface()
 
 		.def("isEventActive", &CyGame::isEventActive, "bool (int /*EventTriggerTypes*/ eTrigger)")
 		.def("doControl", &CyGame::doControl, "void (int /*ControlTypes*/ iControl)")
+		// PB Mod begin
+		.def("setCivPassword", &CyGame::setCivPassword, "void (int /*PlayerId*/, string, string) - Allows change of passwords over webinterface")
+		.def("isDiploScreenUp", &CyGame::isDiploScreenUp, "bool ()")
+		// PB Mod end
 		;
 
 	python::class_<CyDeal>("CyDeal")

--- a/CyGlobalContext.cpp
+++ b/CyGlobalContext.cpp
@@ -633,3 +633,13 @@ CvTurnTimerInfo* CyGlobalContext::getTurnTimerInfo(int i) const
 {
 	return &(GC.getTurnTimerInfo((TurnTimerTypes) i));
 }
+
+// PB Mod begin
+void CyGlobalContext::sendChat(std::wstring szString, int targetType){
+	gDLL->sendChat(szString, (ChatTargetTypes) targetType);
+}
+
+void CyGlobalContext::sendPause(int iPauseID = -1){
+	gDLL->sendPause(iPauseID);
+}
+// PB Mod end

--- a/CyGlobalContext.h
+++ b/CyGlobalContext.h
@@ -316,6 +316,16 @@ public:
 	int getINVALID_PLOT_COORD() const { return GC.getINVALID_PLOT_COORD(); }
 	int getNUM_CITY_PLOTS() const { return GC.getNUM_CITY_PLOTS(); }
 	int getCITY_HOME_PLOT() const { return GC.getCITY_HOME_PLOT(); }
+	
+	// PB Mod begin
+	mutable CvString tmp;
+	const char * getAltrootDir( ) const { 
+		tmp.Convert( gDLL->GetPitbossSmtpLogin() );
+		return tmp.GetCString();
+	}
+	void sendChat(std::wstring szString, int targetType);
+	void sendPause(int iPauseID);
+	// PB Mod end
 };
 
 #endif	// CyGlobalContext_h

--- a/CyGlobalContextInterface4.cpp
+++ b/CyGlobalContextInterface4.cpp
@@ -170,5 +170,11 @@ void CyGlobalContextPythonInterface4(python::class_<CyGlobalContext>& x)
 		.def("getContactTypes", &CyGlobalContext::getContactTypes, "string () - Returns enum string")
 
 		.def("getDiplomacyPowerTypes", &CyGlobalContext::getDiplomacyPowerTypes, "string () - Returns enum string")
+		
+		// PB Mod begin
+		.def("getAltrootDir", &CyGlobalContext::getAltrootDir, "string ( )" )
+		.def("sendChat", &CyGlobalContext::sendChat, "void (TCHAR, int /*ChatTargetTypes*/ targetType )" )
+		.def("sendPause", &CyGlobalContext::sendPause, "void (int iPlayerID)" )
+		// PB Mod end
 		;
 }

--- a/CyMessageControl.cpp
+++ b/CyMessageControl.cpp
@@ -19,6 +19,13 @@ void CyMessageControl::sendTurnComplete()
 	CvMessageControl::getInstance().sendTurnComplete();
 }
 
+// PB Mod begin
+void CyMessageControl::sendTurnCompleteAll()
+{
+	CvMessageControl::getInstance().sendTurnCompleteAll();
+}
+// PB Mod end
+
 void CyMessageControl::sendUpdateCivics(boost::python::list& iCivics)
 {
 	int *PYiCivics = NULL;		//	do not delete this memory

--- a/CyMessageControl.h
+++ b/CyMessageControl.h
@@ -13,6 +13,9 @@ public:
 	void sendPushOrder(int iCityID, int eOrder, int iData, bool bAlt, bool bShift, bool bCtrl);
 	void sendDoTask(int iCity, int eTask, int iData1, int iData2, bool bOption, bool bAlt, bool bShift, bool bCtrl);
 	void sendTurnComplete();
+	// PB Mod begin
+	void sendTurnCompleteAll();
+	// PB Mod end
 	void sendUpdateCivics(boost::python::list& iCivics);
 	void sendResearch(int eTech, bool bShift);
 	void sendPlayerOption (int /*PlayerOptionTypes*/ eOption, bool bValue);

--- a/CyMessageControlInterface.cpp
+++ b/CyMessageControlInterface.cpp
@@ -11,6 +11,9 @@ void CyMessageControlInterface()
 		.def("sendPushOrder", &CyMessageControl::sendPushOrder, "void (int iCityID, int eOrder, int iData, bool bAlt, bool bShift, bool bCtrl)")
 		.def("sendDoTask", &CyMessageControl::sendDoTask, "void (int iCity, int eTask, int iData1, int iData2, bool bOption, bool bAlt, bool bShift, bool bCtrl)")
 		.def("sendTurnComplete", &CyMessageControl::sendTurnComplete, "void () - allows you to force a turn to end")
+		// PB Mod begin
+		.def("sendTurnCompleteAll", &CyMessageControl::sendTurnCompleteAll, "void () - allows you to force a turn to end for all players")
+		// PB Mod end
 		.def("sendUpdateCivics", &CyMessageControl::sendUpdateCivics, "void (list iCivics)")
 		.def("sendResearch", &CyMessageControl::sendResearch, "void (int eTech, bool bShift)")
 		.def("sendPlayerOption", &CyMessageControl::sendPlayerOption, "void (int /*PlayerOptionTypes*/ eOption, bool bValue)")

--- a/CyPlayer.cpp
+++ b/CyPlayer.cpp
@@ -106,6 +106,14 @@ std::wstring CyPlayer::getName()
 	return m_pPlayer ? m_pPlayer->getName() : std::wstring();
 }
 
+// PB Mod begin
+void CyPlayer::setName(std::wstring szNewValue)
+{
+	if (m_pPlayer)
+		m_pPlayer->setName(CvWString(szNewValue));
+}
+// PB Mod end
+
 std::wstring CyPlayer::getNameForm(int iForm)
 {
 	return m_pPlayer ? m_pPlayer->getName((uint)iForm) : std::wstring();
@@ -1488,6 +1496,15 @@ int CyPlayer::getPlayerTextColorA()
 {
 	return m_pPlayer ? m_pPlayer->getPlayerTextColorA() : -1;
 }
+
+// PB Mod begin
+void CyPlayer::setPlayerColor(int /*PlayerColorTypes*/ eColor)
+{
+	if( m_pPlayer){
+		m_pPlayer->setPlayerColor((PlayerColorTypes)eColor);
+	}
+}
+// PB Mod end
 
 int CyPlayer::getSeaPlotYield(YieldTypes eIndex)
 {

--- a/CyPlayer.h
+++ b/CyPlayer.h
@@ -42,6 +42,9 @@ public:
 	bool isHuman();
 	bool isBarbarian();
 	std::wstring getName();
+	// PB Mod begin
+	void setName(std::wstring szNewValue);
+	// PB Mod end
 	std::wstring getNameForm(int iForm);
 	std::wstring getNameKey();
 	std::wstring getCivilizationDescription(int iForm);
@@ -351,6 +354,10 @@ public:
 	int getPlayerTextColorG();
 	int getPlayerTextColorB();
 	int getPlayerTextColorA();
+	
+	// PB Mod begin
+	void setPlayerColor(int /*PlayerColorTypes*/ eColor);
+	// PB Mod end
 
 	int getSeaPlotYield(YieldTypes eIndex);
 	int getYieldRateModifier(YieldTypes eIndex);

--- a/CyPlayerInterface1.cpp
+++ b/CyPlayerInterface1.cpp
@@ -40,6 +40,9 @@ void CyPlayerPythonInterface1(python::class_<CyPlayer>& x)
 		.def("isHuman", &CyPlayer::isHuman, "bool ()")
 		.def("isBarbarian", &CyPlayer::isBarbarian, "bool () - returns True if player is a Barbarian")
 		.def("getName", &CyPlayer::getName, "str ()")
+		// PB Mod begin
+		.def("setName", &CyPlayer::setName, "void (TCHAR szNewValue) - sets the name to szNewValue")
+		// PB Mod end
 		.def("getNameForm", &CyPlayer::getNameForm, "str ()")
 		.def("getNameKey", &CyPlayer::getNameKey, "str ()")
 		.def("getCivilizationDescription", &CyPlayer::getCivilizationDescription, "str() - returns the Civilization Description String")
@@ -337,6 +340,10 @@ void CyPlayerPythonInterface1(python::class_<CyPlayer>& x)
 		.def("getPlayerTextColorG", &CyPlayer::getPlayerTextColorG, "int ()")
 		.def("getPlayerTextColorB", &CyPlayer::getPlayerTextColorB, "int ()")
 		.def("getPlayerTextColorA", &CyPlayer::getPlayerTextColorA, "int ()")
+		
+		// PB Mod begin
+		.def("setPlayerColor", &CyPlayer::setPlayerColor, "void (PlayerColorTypes eColor) - set the color ID of the player")
+		// PB Mod end
 
 		.def("getSeaPlotYield", &CyPlayer::getSeaPlotYield, "int (YieldTypes eIndex)")
 		.def("getYieldRateModifier", &CyPlayer::getYieldRateModifier, "int (YieldTypes eIndex)")


### PR DESCRIPTION
Merged with PB Mod_v5. Normal pitboss cannot be used anymore, you must
use PB Mod pitboss available
http://forums.civfanatics.com/showthread.php?t=533346 or
https://github.com/YggdrasiI/PBStats. More information about PB Mod is
also available there. Main features are fix for pause/trade screen bug
and admin webinterface for pitboss. It also includes language dependent
OOS bugfix for city naming, empty login screen workaround and espionage
popups on load bugfix.

Units in influence flipped star system won't be deleted when in war with
new owner, but will just be bumped outside enemy borders.

Tech score is now counted only once for team and not per player.
